### PR TITLE
Fix fatal errors from reorganization of authorize.net

### DIFF
--- a/vendor/omnipay/authorizenet/src/AIMGateway.php
+++ b/vendor/omnipay/authorizenet/src/AIMGateway.php
@@ -179,7 +179,7 @@ class AIMGateway extends AbstractGateway
      */
     public function query(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\AuthorizeNet\Message\QueryRequest', $parameters);
+        return $this->createRequest('\Omnipay\AuthorizeNet\Message\Query\QueryRequest', $parameters);
     }
 
     /**

--- a/vendor/omnipay/authorizenet/src/Message/Query/AIMAbstractQueryRequest.php
+++ b/vendor/omnipay/authorizenet/src/Message/Query/AIMAbstractQueryRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\AuthorizeNet\Message\Query;
 
+use Omnipay\AuthorizeNet\Message\AIMAbstractRequest;
+
 /**
  * Authorize.Net AIM Abstract Request
  */


### PR DESCRIPTION
When I run `wp cv api PaymentProcessor.query payment_processor_id=7` I get:
```php
PHP Fatal error:  Class '\Omnipay\AuthorizeNet\Message\QueryRequest' not found in /home/members/healthcarenow/sites/dev.healthcare-now.org/web/wp-content/civicrm/extensions/nz.co.fuzion.omnipaymultiprocessor/vendor/omnipay/common/src/Omnipay/Common/AbstractGateway.php on line 322
```

I fix that error, and I get:
```php
PHP Fatal error:  Class 'Omnipay\AuthorizeNet\Message\Query\AIMAbstractRequest' not found in /home/members/healthcarenow/sites/dev.healthcare-now.org/web/wp-content/civicrm/extensions/nz.co.fuzion.omnipaymultip$
ocessor/vendor/omnipay/authorizenet/src/Message/Query/AIMAbstractQueryRequest.php on line 9
```

This seems related to a reorganization of Authorize.net files that happened last month.  I know this PR should go against `https://github.com/thephpleague/omnipay-authorizenet/blob/master/src/AIMGateway.php` but it seems like maybe I'm doing something really wrong here so I figured I'd check in with you first before embarrassing myself?

Jon