### PR TITLE
Format currency before passing to processor

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -400,6 +400,11 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
     else {
       $amount = (float) CRM_Utils_Rule::cleanMoney($params['amount']);
     }
+    if (!empty($params['currencyID'])) {
+      $amount = CRM_Utils_Money::format($amount, $params['currencyID'], NULL, TRUE);
+    }
+
+
     $creditCardOptions = array(
       'amount' => $amount,
       // Contribution page in 4.4 (confirmed Event online, 4.7) passes currencyID - not sure which passes currency (if any).


### PR DESCRIPTION
@eileenmcnaughton Thoughts please?  Had an issue recently where sagepay expects a currency formatted to two decimal places but the payment processor was passed one with multiple decimal places because an extension modified the amount before submission (to pro-rata the membership).  So we got a value like 10.8333333 which sagepay doesn't like :-)

It's fixed in the extension, but should omnipay be doing any checking/formatting of the amounts?