### PR TITLE
Fixed redirect issue on Event registration

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -791,6 +791,20 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    * @param null|object $response
    */
   protected function redirectOrExit($outcome, $response = NULL) {
+    // Session is reset for event registration for unknown reason.
+    // set the component so that the url is build correctly.
+    if (!empty($this->transaction_id)) {
+      $participantCount = civicrm_api3('ParticipantPayment', 'getcount', [
+        'contribution_id' => $this->transaction_id,
+      ]);
+      if ($participantCount) {
+        $this->_component = 'event';
+      }
+      else {
+        $this->_component = 'contribute';
+      }
+    }
+
     switch ($outcome) {
       case 'fail':
         $userMsg = ts('Your payment was not successful. Please try again');
@@ -1324,4 +1338,3 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
   }
 
 }
-


### PR DESCRIPTION
When using sagepay payment processor to purchase a event user get error saying 'Your browser session has expired and we are unable to complete your form submission. We have returned you to the initial step so you can complete and resubmit the form. If you experience continued difficulties, please contact us for assistance.' even though the payment is successful and recorded successfully in CiviCRM. The user also gets confirmation email saying they have registered for event.

Digging into the code i found that extension is saving the success or fail url in session before leaving CiviCRM to go to Payment Gateway screen and when it comes back it doesn't find the url in session and when it tries to rebuild the url and it defaults to use Contribution thank you page(because the component is not being set) which causes the controller to throw above error. 

My PR fixes the problem by just checking if the contribution is linked to Participant and based on it sets the component. 

@eileenmcnaughton @mattwire Can you please review this for me?