### PR TITLE
Applies #17 for non-redirect processors.

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -117,6 +117,8 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
           ->send();
       }
       if ($response->isSuccessful()) {
+        $this->cleanupClassForSerialization(TRUE);
+
         if (method_exists($response, 'getCardReference') && $response->getCardReference()) {
           $params['token'] = $response->getCardReference();
         }


### PR DESCRIPTION
I ran into #17, but with Beanstream, which is a non-redirect API.