### PR TITLE
Support setting specific gateway params via metadata

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -336,6 +336,9 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    */
   function getProcessorFields() {
     $labelFields = $result = array();
+
+    $result = $this->getProcessorTypeMetadata('gateway_params');
+
     foreach ($this->_configurationFields as $configField) {
       if (!empty($this->_paymentProcessor[$configField])) {
         $labelFields[$configField] = "{$configField}_label";

--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -57,6 +57,7 @@ return array(
           ),
         ),
         'ipn_processing_delay' => 0,
+        'gateway_params' => ['billingForShipping' => 1],
       ),
       'params' =>
         array(


### PR DESCRIPTION
Omnipay provides a way of setting gateway parameters and a hardcoded list of the "defaults".  This PR allows setting non-default parameters via the extension metadata.