### PR TITLE
Fix $0 payments failing due to payment processor

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -127,6 +127,12 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    *   The result in an nice formatted array (or an error object)
    */
   public function doPayment(&$params, $component = 'contribute') {
+    // If we have a $0 amount, skip call to processor and set payment_status to Completed.
+    if ($params['amount'] == 0) {
+      return [
+        'payment_status_id' => array_search('Completed', CRM_Contribute_BAO_Contribution::buildOptions('contribution_status_id', 'validate')),
+      ];
+    }
     $params['component'] = strtolower($component);
     $this->initialize($params);
     $this->saveBillingAddressIfRequired($params);


### PR DESCRIPTION
Payments are processed by omnipay even if amount is $0. To replicate -

- Create a free membership type with fee = $0.
- Add this to a contribution page with omnipay processor(PxPay) enabled.
- Submit the page with $0 amount. The payment is set to failed with no update in membership.

Seems we should just skip the call in case of zero amount? We follow the same procedure in core - 
https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment.php#L1234-L1240