### PR TITLE
Fix recording of recur payment

### DIFF
--- a/api/v3/Job/ProcessRecurring.php
+++ b/api/v3/Job/ProcessRecurring.php
@@ -11,7 +11,7 @@
 function civicrm_api3_job_process_recurring($params) {
   $omnipayProcessors = civicrm_api3('PaymentProcessor', 'get', array('class_name' => 'Payment_OmnipayMultiProcessor'));
   $recurringPayments = civicrm_api3('ContributionRecur', 'get', array(
-    'next_sched_contribution_date' => ['BETWEEN' => ['today', 'tomorrow']],
+    'next_sched_contribution_date' => ['BETWEEN' => [date('Y-m-d 00:00:00'), date('Y-m-d 12:59:59')]],
     'payment_processor_id' => array('IN' => array_keys($omnipayProcessors['values'])),
     'contribution_status_id' => array('IN' => array('In Progress', 'Pending', 'Overdue')),
     'options' => array('limit' => 0),


### PR DESCRIPTION
Continuing from - https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/pull/78#discussion_r289779091

I've tested it on local. Problem that I see is -

Recur payment next_sched_date = 4th June.
Job execution date = 3rd June.
API with parameter -
    
    'next_sched_contribution_date' => ['BETWEEN' => ['today', 'tomorrow']],` 

gets the payments scheduled for 4th June.

Replaced the param with 

    'next_sched_contribution_date' => ['BETWEEN' => [date('Y-m-d 00:00:00'), date('Y-m-d 12:59:59')]],`, 

only 3rd June payments were received.