### PR TITLE
Ajax Permissions: change from AND to OR

### DIFF
--- a/CRM/Utils/RestPreapprove.php
+++ b/CRM/Utils/RestPreapprove.php
@@ -17,7 +17,7 @@ class CRM_Utils_RestPreapprove extends CRM_Utils_REST {
     // we are only using it for a php compare nothing risky.
     $action = strtolower(CRM_Utils_Array::value('action', $_REQUEST));
     $entity = str_replace('_', '', strtolower(CRM_Utils_Array::value('entity', $_REQUEST)));
-    if (($action !== 'preapprove' || $entity !== 'paymentprocessor') && !CRM_Core_Permission::check(['access CiviCRM', 'access AJAX API'])) {
+    if (($action !== 'preapprove' || $entity !== 'paymentprocessor') && !CRM_Core_Permission::check([['access CiviCRM', 'access AJAX API']])) {
       CRM_Utils_System::permissionDenied();
       return NULL;
     }


### PR DESCRIPTION
Related to #108: on civicrm.org, Ajax requests that require "access AJAX API" but do not require "access CiviCRM" are generating 403 Access Denied.

Ex: as a regular Drupal user, try to import punches from:  
https://civicrm.org/civicrm/timetrack/import#/import

The `timetrackpunchlist.preview` will generate a 403.

We grant users "access AJAX API", but not "access CiviCRM".

If I understand the `check` syntax correctly, the double-array means "OR" rather than AND, and this is the behaviour of `civicrm/ajax/rest`?