### PR TITLE
Add basic validation

### DIFF
--- a/Metadata/js/omnipay_PaypalRest.js
+++ b/Metadata/js/omnipay_PaypalRest.js
@@ -5,6 +5,27 @@
 
   function renderPaypal() {
     paypal.Buttons({
+
+
+        onInit: function(data, actions) {
+          // Set up the buttons.
+          if (form.valid()) {
+            actions.enable()
+          }
+          else {
+            actions.disable();
+          }
+
+          form.on('blur keyup change', 'input', function (event) {
+            if (form.valid()) {
+              actions.enable()
+            }
+            else {
+              actions.disable();
+            }
+          });
+        },
+
         createBillingAgreement: function (data, actions) {
 
           var frequencyInterval = $('#frequency_interval').val() || 1;
@@ -65,7 +86,7 @@
   }
 
   var paypalScriptURL = 'https://www.paypal.com/sdk/js?client-id=' + CRM.vars.omnipay.client_id + '&currency=' + CRM.vars.omnipay.currency + '&commit=false&vault=true';
-  CRM.loadScript(paypalScriptURL, false)
-    .done(renderPaypal);
+  CRM.loadScript(paypalScriptURL, false).done(renderPaypal);
+
 
 })(CRM.$);

--- a/info.xml
+++ b/info.xml
@@ -15,10 +15,10 @@
     <url desc="Licensing">http://civicrm.org/licensing</url>
   </urls>
   <releaseDate>2019-07-07</releaseDate>
-  <version>3.6</version>
+  <version>3.7</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.13</ver>
+    <ver>5.17</ver>
   </compatibility>
   <comments>This module integrates the omnipay library with CiviCRM. This release is for Omnipay 3.x and requires php 7.1. All new development will be here but 2.x series will continue to work.</comments>
   <civix>

--- a/omnipaymultiprocessor.php
+++ b/omnipaymultiprocessor.php
@@ -101,6 +101,8 @@ function omnipaymultiprocessor_civicrm_alterSettingsFolders(&$metaDataFolders) {
 
 function omnipaymultiprocessor_civicrm_preProcess($formName, &$form) {
   if ($formName === 'CRM_Contribute_Form_Contribution_Main') {
+    $form->assign('isJsValidate', TRUE);
+    CRM_Core_Resources::singleton()->addVars('form', ['suppressAlerts' => 1]);
     if (!empty($form->_values['is_recur'])) {
       $recurOptions = [
         'is_recur_interval' =>  $form->_values['is_recur_interval'],


### PR DESCRIPTION
This has the effect of disabling the paypal buttons until basic validate passes. The goal
here is to prevent the scenario where someone clicks on the paypal button, authorizes the payment
and then has to re-authorize due to the form submission not being accepted. We REALLY don't want
to take their authorization until the form is correct. Note that there is
an api we could use (ContributionPage.validate ['action' => 'create', 'id' => x]

This attempt https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/pull/98/ was against
the previous version of paypal smartbuttons but it demonstrates the api

I couldn't find any evidence of being able to listen to when a form is valid - posts like this
https://github.com/jquery-validation/jquery-validation/issues/1996
suggest the method I used.

The easiest way to test this is by submitting the form as an anonymous user without
entering an email - you should not be able to launch the paypal form and there should be red writing next to
the field.

Paypal documentation on it

https://developer.paypal.com/docs/checkout/integration-features/validation/?mark=validat#synchronous-validation

Note the async mode is BAD - it launches the modal & does the check while loading. Avoid. Perhaps we could only render
the paypal button when valid - like they suggest - but then switching back & forth with valid & invalid gets hard.

Am on the fence about hiding
Unfortunately without a core patch you will ALSO get an alert. I am proposing a core patch along side this
which will suppress it in core. Really I think it would be best to put the message down by the paypal button
(possibly hiding it) but because of the need to call it at the start it needs to be less nasty.