### PR TITLE
Sagepay one-off payments

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -616,7 +616,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    * we copy billing values where shipping values are empty
    */
   protected function copyShippingFieldsFromBillingIfEmpty(&$cardFields) {
-    $fieldsSuffixes = [ 'Address1', 'Address2', 'City', 'Postcode', 'State', 'Country' ];
+    $fieldSuffixes = [ 'Address1', 'Address2', 'City', 'Postcode', 'State', 'Country' ];
     foreach($fieldSuffixes as $fieldSuffix) {
       $billingField = 'billing' . $fieldSuffix;
       $shippingField = 'shipping' . $fieldSuffix;

--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -820,6 +820,24 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
   }
 
   /**
+   * Get details of CiviCRM mandatory and optional address fields.
+   *
+   * @param int $billingLocationID
+   *
+   * @return array
+   */
+  public function getBillingAddressFieldsMetadata($billingLocationID = NULL) {
+    $metadata = parent::getBillingAddressFieldsMetadata($billingLocationID);
+    $fields = $this->getProcessorTypeMetadata('fields');
+    $fieldDetails = $this->getProcessorTypeMetadata('field_details');
+    foreach($fieldDetails as $key => $value) {
+      $metaKey = $fields['billing_fields'][$key];
+      $metadata[$metaKey] = array_merge($metadata[$metaKey], $value);
+    }
+    return $metadata;
+  }
+
+  /**
    * Handle response from processor.
    *
    * We simply get the params from the REQUEST and pass them to a static function that

--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -63,6 +63,7 @@ return array(
         ),
         'ipn_processing_delay' => 0,
         'notification_from_different_session' => TRUE,
+        'continuous_authority' => TRUE,
       ),
       'params' =>
         array(

--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -74,7 +74,7 @@ return array(
           'payment_type' => 3,
           'url_recur_default' => 'http://unused.com',
           'url_recur_test_default' => 'http://unused.com',
-          'is_recur' => 1,
+          'is_recur' => 0,
         ),
     ),
 );

--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -57,6 +57,7 @@ return array(
           ),
         ),
         'ipn_processing_delay' => 0,
+        'notification_from_different_session' => TRUE,
       ),
       'params' =>
         array(
@@ -67,10 +68,13 @@ return array(
           'user_name_label' => 'Vendor',
           'password_label' => 'unused',
           'signature_label' => 'unused',
-          'site_url' => '',
+          'site_url' => 'unused',
           'class_name' => 'Payment_OmnipayMultiProcessor',
           'billing_mode' => 4,
           'payment_type' => 3,
+          'url_recur_default' => 'http://unused.com',
+          'url_recur_test_default' => 'http://unused.com',
+          'is_recur' => 1,
         ),
     ),
 );

--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -56,6 +56,11 @@ return array(
             'postal_code' => "billing_postal_code-{$billingLocationID}",
           ),
         ),
+        'field_details' => array(
+          'state_province' => array(
+            'is_required' => FALSE,
+          )
+        ),
         'ipn_processing_delay' => 0,
         'notification_from_different_session' => TRUE,
       ),

--- a/api/v3/Job/ProcessRecurring.php
+++ b/api/v3/Job/ProcessRecurring.php
@@ -35,29 +35,51 @@ function civicrm_api3_job_process_recurring($params) {
         'is_email_receipt' => FALSE,
       ));
 
-      $payment = civicrm_api3('PaymentProcessor', 'pay', array(
-        'amount' => $originalContribution['total_amount'],
-        'currency' => $originalContribution['currency'],
-        'payment_processor_id' => $paymentProcessorID,
-        'contributionID' => $pending['id'],
-        'contribution_id' => $pending['id'],
-        'contactID' => $originalContribution['contact_id'],
-        'description' => ts('Repeat payment, original was ' . $originalContribution['id']),
-        'token' => civicrm_api3('PaymentToken', 'getvalue', [
-          'id' => $recurringPayment['payment_token_id'],
-          'return' => 'token',
-        ]),
-        'payment_action' => 'purchase',
-      ));
-      $payment = reset($payment['values']);
+      if (!is_continuous_authority($omnipayProcessors['values'][$paymentProcessorID])) {
+        $payment = civicrm_api3('PaymentProcessor', 'pay', array(
+          'amount' => $originalContribution['total_amount'],
+          'currency' => $originalContribution['currency'],
+          'payment_processor_id' => $paymentProcessorID,
+          'contributionID' => $pending['id'],
+          'contribution_id' => $pending['id'],
+          'contactID' => $originalContribution['contact_id'],
+          'description' => ts('Repeat payment, original was ' . $originalContribution['id']),
+          'token' => civicrm_api3('PaymentToken', 'getvalue', [
+            'id' => $recurringPayment['payment_token_id'],
+            'return' => 'token',
+          ]),
+          'payment_action' => 'purchase',
+        ));
+        $payment = reset($payment['values']);
 
-      civicrm_api3('Contribution', 'completetransaction', array(
-        'id' => $pending['id'],
-        'trxn_id' => $payment['trxn_id'],
-        'payment_processor_id' => $paymentProcessorID,
-      ));
-      $result['success']['ids'] = $recurringPayment['id'];
+        civicrm_api3('Contribution', 'completetransaction', array(
+          'id' => $pending['id'],
+          'trxn_id' => $payment['trxn_id'],
+          'payment_processor_id' => $paymentProcessorID,
+        ));
+        $result['success']['ids'] = $recurringPayment['id'];
+      } else {
+        $payment = civicrm_api3('PaymentProcessor', 'pay', array(
+          'amount' => $originalContribution['total_amount'],
+          'currency' => $originalContribution['currency'],
+          'payment_processor_id' => $paymentProcessorID,
+          'contributionID' => $pending['id'],
+          'contribution_id' => $pending['id'],
+          'original_contribution_trxn_id' => $originalContribution['trxn_id'],
+          'continuous_authority_repeat' => TRUE,
+          'contactID' => $originalContribution['contact_id'],
+          'description' => ts('Repeat payment, original was ' . $originalContribution['id']),
+          'payment_action' => 'purchase',
+        ));
+        $payment = reset($payment['values']);
 
+        civicrm_api3('Contribution', 'completetransaction', array(
+          'id' => $pending['id'],
+          'trxn_id' => $payment['trxn_id'],
+          'payment_processor_id' => $paymentProcessorID,
+        ));
+        $result['success']['ids'] = $recurringPayment['id'];
+      }
     }
     catch (CiviCRM_API3_Exception $e) {
       // Failed - what to do?
@@ -83,4 +105,45 @@ function civicrm_api3_job_process_recurring($params) {
  * @return array
  */
 function _civicrm_api3_job_process_recurring_spec(&$params) {
+}
+
+function is_continuous_authority($paymentProcessor) {
+  $paymentProcessorType = civicrm_api3('PaymentProcessorType', 'get', array(
+    'id' => $paymentProcessor['payment_processor_type_id'],
+    'sequential' => 1,
+  ));
+
+  $property = get_processor_type_property($paymentProcessorType['values'][0]['name'], 'continuous_authority');
+
+  if($property['found']) {
+    return $property['value'];
+  } else {
+    return FALSE;
+  }
+}
+
+function get_processor_type_by_name($processorTypeName, $entity) {
+  if($entity['entity'] != 'payment_processor_type') { return FALSE; }
+  if(!array_key_exists('params', $entity)) { return FALSE; }
+  if(!array_key_exists('name', $entity['params'])) { return FALSE; }
+  return $entity['params']['name'] == $processorTypeName;
+}
+
+function get_processor_type_metadata($processorTypeName) {
+  $entities = [];
+  omnipaymultiprocessor_civicrm_managed($entities);
+  $filter_by_name = function($entity) use($processorTypeName) {
+    return get_processor_type_by_name($processorTypeName, $entity);
+  };
+  return array_values(array_filter($entities, $filter_by_name))[0];
+}
+
+function get_processor_type_property($processorTypeName, $propertyName) {
+  $processorTypeMetadata = get_processor_type_metadata($processorTypeName);
+  if(!array_key_exists('metadata', $processorTypeMetadata)) { return array('found' => FALSE); }
+  if(!array_key_exists($propertyName, $processorTypeMetadata['metadata'])) { return array('found' => FALSE); }
+  return array(
+    'found' => TRUE,
+    'value' => $processorTypeMetadata['metadata'][$propertyName],
+  );
 }


### PR DESCRIPTION
Hello @eileenmcnaughton,

Here is my first attempt to make Sagepay payments work. It only enables one-off payments (I'll be working on recurring ones but they're not covered yet).

Can you let me know if these changes look correct to you?

## Notification from different session

I added a `notification_from_different_session` payment processor metadata to identify a Sagepay behavior: contributions are completed by their notification services and they redirect the user to CiviCRM after the payment is completed.

As the qfKey is stored in the user's browser session and Sagepay also requires us remembering a `SecurityKey`, both the qfKey and the SecurityKey are (pre)-stored in the contribution and then queried from there during the notification process.

## Shipping fields can't be empty

To prevent a `3140 : The DeliveryCountry value is invalid`, I copied them from the billing data, just in case they are missing.