### PR TITLE
Fixes for PayPal Checkout with drupal webform and other CiviCRM forms

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -357,7 +357,8 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
         $jsVariables[$clientSideKey] = $this->_paymentProcessor[$key];
       }
     }
-    CRM_Core_Resources::singleton()->addVars('omnipay', $jsVariables);
+
+    \Civi::resources()->addVars('omnipay', $jsVariables, 'billing-block');
     if (is_array($regions)) {
       foreach ($regions as $region => $additions) {
         foreach ($additions as $addition) {

--- a/Metadata/js/omnipay_PaypalRest.js
+++ b/Metadata/js/omnipay_PaypalRest.js
@@ -3,6 +3,29 @@
   var form = $('#billing-payment-block').closest('form');
   var qfKey = $('[name=qfKey]', form).val();
 
+  /**
+   * Get the total amount on the form
+   * @returns {number}
+   */
+  function getTotalAmount() {
+    var totalFee = 0.0;
+    if (typeof CRM.payment.getTotalAmount !== 'undefined') {
+      return CRM.payment.getTotalAmount();
+    }
+
+    if (typeof calculateTotalFee == 'function') {
+        // This is ONLY triggered in the following circumstances on a CiviCRM contribution page:
+        // - With a priceset that allows a 0 amount to be selected.
+        // - When we are the ONLY payment processor configured on the page.
+        totalFee = parseFloat(calculateTotalFee());
+    }
+    else if (document.getElementById('total_amount')) {
+      // The input#total_amount field exists on backend contribution forms
+      totalFee = parseFloat(document.getElementById('total_amount').value);
+    }
+    return totalFee;
+  }
+
   function renderPaypal() {
     paypal.Buttons({
 
@@ -30,7 +53,7 @@
 
           var frequencyInterval = $('#frequency_interval').val() || 1;
           var frequencyUnit = $('#frequency_unit').val() ? $('#frequency_interval').val() : CRM.vars.omnipay.frequency_unit;
-          var paymentAmount = calculateTotalFee();
+          var paymentAmount = getTotalAmount();
           var isRecur = $('#is_recur').is(":checked");
           var recurText = isRecur ? ' recurring' : '';
 


### PR DESCRIPTION
This fixes two issues with PayPal Checkout implementation.

1. Does not work with multiple payment processors on the form and PayPal is not the default:
  Fixed by loading variables into `billing-block` instead of default (`html-header`).

2. `calculateTotalFee` function only exists in specific circumstances on certain CiviCRM forms. If it doesn't exist the current PayPal checkout implementation crashes.
  Fixed by using a copy of implementation from mjwshared/Stripe where we check for various ways of getting the amount from the form. To work with drupal webform requires this PR https://github.com/colemanw/webform_civicrm/pull/331

I have been shipping now for a while and developing a `CRM.payment` library to help with javascript processor implementations. This + the webform PR is the first implementation that would "publicly" use one of the functions - `getTotalAmount()` and it's designed in such a way that 3rd-party integrations (such as webform) can ship and maintain their own copies of these functions.  See https://lab.civicrm.org/extensions/mjwshared/-/blob/0.9/js/crm.payment.js#L160-163 and https://github.com/colemanw/webform_civicrm/pull/331/files#diff-3d9bb68a7f54911dbc5f1017646f40caR137-R142

This PR does not required mjwshared and is written in a way that will work whether or not it finds a CRM.payment library.