### PR TITLE
Add handling for sagePay intolerance for empty card

### DIFF
--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -74,6 +74,9 @@ return [
       'ipn_processing_delay' => 0,
       // See https://github.com/thephpleague/omnipay-sagepay/pull/154
       'pass_through_fields' => ['billingForShipping' => 1],
+      // Hopefully temporary fix.
+      // https://github.com/thephpleague/omnipay-sagepay/pull/158
+      'is_pass_null_for_empty_card' => TRUE,
     ],
     'params' =>
       [


### PR DESCRIPTION
Hopefully https://github.com/thephpleague/omnipay-sagepay/pull/158
will be merged but for now SagePay assumes that an empty card is an ignore-everything-else-card