### PR TITLE
Sagepay recurring support

### DIFF
--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -77,6 +77,8 @@ return [
       // Hopefully temporary fix.
       // https://github.com/thephpleague/omnipay-sagepay/pull/158
       'is_pass_null_for_empty_card' => TRUE,
+      'create_card_action' => 'purchase',
+      'token_pay_action' => 'repeatPurchase',
     ],
     'params' =>
       [
@@ -89,6 +91,7 @@ return [
         'class_name' => 'Payment_OmnipayMultiProcessor',
         'billing_mode' => 4,
         'payment_type' => 3,
+        'is_recur' => TRUE,
       ],
   ],
 ];

--- a/tests/phpunit/Mock/SagepayRepeatAuthorize.txt
+++ b/tests/phpunit/Mock/SagepayRepeatAuthorize.txt
@@ -1,0 +1,12 @@
+HTTP/1.1 200 OK
+Date: Thu, 20 Feb 2020 10:25:00 GMT
+
+VPSProtocol=3.00
+Status=OK
+StatusDetail=0000 : The Authorisation was Successful.
+VPSTxId={
+ B4453DF4-E7D1-1CF3-ED60-6DA4AEA78D08
+}
+SecurityKey=BEY5QUAYGL
+TxAuthNo=8365828
+BankAuthCode=999777"

--- a/tests/phpunit/SagepayTest.php
+++ b/tests/phpunit/SagepayTest.php
@@ -7,6 +7,8 @@ use Civi\Test\TransactionalInterface;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Civi\Test\Api3TestTrait;
+use Civi\Api4\ContributionRecur;
+use Civi\Api4\Contribution;
 
 /**
  * Sage pay tests for one-off payment.
@@ -98,6 +100,71 @@ class SagepayTest extends TestCase implements HeadlessInterface, HookInterface, 
 
     $contribution = $this->callAPISuccess('Contribution', 'get', [
       'return' => ['trxn_id'],
+      'contact_id' => $this->ids['Contact']['id'],
+      'sequential' => 1,
+    ]);
+
+    // Reset session as this would come in from the sage server.
+    CRM_Core_Session::singleton()->reset();
+    $ipnParams = $this->getSagepayPaymentConfirmation($this->paymentProcessorID, $contribution['id']);
+    $this->signRequest($ipnParams);
+    try {
+      CRM_Core_Payment_OmnipayMultiProcessor::processPaymentResponse(['processor_id' => $this->paymentProcessorID]);
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      // Check we didn't try to redirect the server.
+      $this->assertArrayNotHasKey('url', $e->errorData);
+      $contribution = \Civi\Api4\Contribution::get(FALSE)
+        ->addWhere('id', '=', $contribution['id'])
+        ->addSelect('contribution_status_id:name', 'trxn_id')->execute()->first();
+      $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
+    }
+  }
+
+
+  /**
+   * When a payment is made, the Sagepay transaction identifier `VPSTxId`,
+   * a secret security key `SecurityKey` and the corresponding `qfKey`
+   * must be saved as part of the `trxn_id` JSON.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function testDoRecurPayment(): void {
+    $this->setMockHttpResponse([
+      'SagepayOneOffPaymentSecret.txt',
+      'SagepayRepeatAuthorize.txt',
+    ]);
+    Civi::$statics['Omnipay_Test_Config'] = [ 'client' => $this->getHttpClient() ];
+
+    $contributionRecur = ContributionRecur::create(FALSE)->setValues([
+      'contact_id' => $this->ids['Contact'],
+      'amount' => 5,
+      'currency' => 'GBP',
+      'frequency_interval' => 1,
+      'start_date' => 'now',
+      'payment_processor_id' => $this->paymentProcessorID,
+    ])->execute()->first();
+
+    Contribution::update(FALSE)->addWhere('id', '=', $this->_contribution['id'])->setValues(['contribution_recur_id' => $contributionRecur['id']])->execute();
+    $transactionSecret = $this->getSagepayTransactionSecret();
+
+    $payment = $this->callAPISuccess('PaymentProcessor', 'pay', [
+      'payment_processor_id' => $this->paymentProcessorID,
+      'amount' => $this->_new['amount'],
+      'qfKey' => $this->getQfKey(),
+      'currency' => $this->_new['currency'],
+      'component' => 'contribute',
+      'email' => $this->_new['card']['email'],
+      'contactID' => $this->ids['Contact']['id'],
+      'contributionID' => $this->_contribution['id'],
+      'contribution_id' => $this->_contribution['id'],
+      'contributionRecurID' => $contributionRecur['id'],
+      'is_recur' => TRUE,
+    ]);
+
+    $contribution = $this->callAPISuccess('Contribution', 'get', [
+      'return' => ['trxn_id'],
       'contact_id' => $this->ids['Contact'],
       'sequential' => 1,
     ]);
@@ -117,6 +184,30 @@ class SagepayTest extends TestCase implements HeadlessInterface, HookInterface, 
         ->addSelect('contribution_status_id:name', 'trxn_id')->execute()->first();
       $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
     }
+    $recur = ContributionRecur::get(FALSE)
+      ->addSelect('payment_token_id')
+      ->addSelect('payment_processor_id')
+      ->addWhere('id', '=', $contributionRecur['id'])
+      ->execute()->first();
+    $this->assertNotEmpty($recur['payment_token_id']);
+    $contribution = $this->callAPISuccess('Contribution', 'repeattransaction', [
+      'contribution_recur_id' => $contributionRecur['id'],
+      'payment_processor_id' => $this->paymentProcessorID,
+    ]);
+    $this->callAPISuccess('PaymentProcessor', 'pay',  [
+      'amount' => $this->_new['amount'],
+      'currency' => $this->_new['currency'],
+      'payment_processor_id' => $this->paymentProcessorID,
+      'contribution_id' => $contribution['id'],
+      'token' => civicrm_api3('PaymentToken', 'getvalue', [
+        'id' => $recur['payment_token_id'],
+        'return' => 'token',
+      ]),
+      'payment_action' => 'purchase',
+    ]);
+
+    $sent = $this->getRequestBodies();
+    $this->assertContains('RelatedTxAuthNo=4898041', $sent[1]);
   }
 
 }


### PR DESCRIPTION
This works but there are a few outstanding considerations

1) Sagepay uses actions that are inconsistent. I have gone with declaring this as metadata
as the 'most' transparent metadata - ie each piece of metadata should not
have a bunch of interwoved assumptions like 'if it's this
action then it's also this action and card is handled this way' but
I hope we can do some upstream work
to make it less ad hoc  - https://github.com/thephpleague/omnipay-sagepay/issues/157

2) I'm a bit on the fence about the approach of creating a token only when it is recurring
and still using transaction data from the contribution.trxn_id. I think overall I prefer
to always create a token since any contribution could be used for a token and not
to save transaction data (over and above the trxn_id) in the contributon.trxn_id
but given I had written it this way I have not preferred that enough to re-write it. Test
cover should facilitate future changes (more or less)