### PR TITLE
Fix contact id assignment

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -831,7 +831,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
           }
         }
         if (!empty($this->contribution['contribution_recur_id']) && ($tokenReference = $response->getCardReference()) != FALSE) {
-          $this->storePaymentToken(array_merge($params, ['contact_id' => $contribution['contact_id']]), $this->contribution['contribution_recur_id'], $tokenReference);
+          $this->storePaymentToken(array_merge($params, ['contact_id' => $this->contribution['contact_id']]), $this->contribution['contribution_recur_id'], $tokenReference);
         }
       }
       catch (CiviCRM_API3_Exception $e) {


### PR DESCRIPTION
seems like a typo, resulting in the following error on PxPay.

```
Fatal error: Uncaught Error: Call to a member function has() on null in /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_extensions/nz.co.fuzion.omnipaymultiprocessor/CRM/Core/Payment/OmnipayMultiProcessor.php:1677 Stack trace:
#0 /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_extensions/nz.co.fuzion.omnipaymultiprocessor/CRM/Core/Payment/OmnipayMultiProcessor.php(1651): CRM_Core_Payment_OmnipayMultiProcessor->getContactID(Array)
#1 /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_extensions/nz.co.fuzion.omnipaymultiprocessor/CRM/Core/Payment/OmnipayMultiProcessor.php(1005): CRM_Core_Payment_OmnipayMultiProcessor->savePaymentToken(Array)
#2 /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_extensions/nz.co.fuzion.omnipaymultiprocessor/CRM/Core/Payment/OmnipayMultiProcessor.php(834): CRM_Core_Payment_OmnipayMultiProcessor->storePaymentToken(Array, ‘62’, ’000001010037048...’)
#3 /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_ex in /srv/www/unwomen/wp.unwomen.org.nz/wp-content/plugins/files/civicrm_extensions/nz.co.fuzion.omnipaymultiprocessor/CRM/Core/Payment/OmnipayMultiProcessor.php on line 1677

```