### PR TITLE
Make state/province not mandatory for SagePay

### DIFF
--- a/Metadata/omnipay_Sagepay_Server.mgd.php
+++ b/Metadata/omnipay_Sagepay_Server.mgd.php
@@ -67,7 +67,6 @@ return [
           'street_address' => "billing_street_address-{$billingLocationID}",
           'city' => "billing_city-{$billingLocationID}",
           'country' => "billing_country_id-{$billingLocationID}",
-          'state_province' => "billing_state_province_id-{$billingLocationID}",
           'postal_code' => "billing_postal_code-{$billingLocationID}",
         ],
       ],

--- a/tests/phpunit/BillingFieldsTest.php
+++ b/tests/phpunit/BillingFieldsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Civi\Api4\Contact;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Civi\Test\Api3TestTrait;
+use Civi\Api4\ContributionRecur;
+use Civi\Api4\Contribution;
+
+/**
+ * Sage pay tests for one-off payment.
+ *
+ * @group headless
+ */
+class BillingFieldsTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use Api3TestTrait;
+  use HttpClientTestTrait;
+
+  /**
+   * ID of payment processor created for test.
+   *
+   * @var int
+   */
+  protected $paymentProcessorID;
+
+  /**
+   * @return \Civi\Test\CiviEnvBuilder
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): \Civi\Test\CiviEnvBuilder {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Setup for test.
+   *
+   * @throws \API_Exception
+   * @throws \CRM_Csore_Exception
+   */
+  public function setUp():void {
+    parent::setUp();
+
+    $paymentProcessorID = (int) $this->callAPISuccess('PaymentProcessor', 'create', [
+      'payment_processor_type_id' => 'omnipay_SagePay_Server',
+      'user_name' => 'sagepay_user',
+      'is_test' => 1,
+      'sequential' => 1,
+    ])['values'][0]['id'];
+
+    $this->processor = $this->callAPISuccess('PaymentProcessor', 'getsingle', [
+      'id' => $paymentProcessorID,
+    ]);
+  }
+
+  public function testStateProvinceNotMandatoryInSagePay() {
+    $processor = new CRM_Core_Payment_OmnipayMultiProcessor('live', $this->processor);
+    $fields = $processor->getBillingAddressFields(5);
+    $this->assertArrayNotHasKey('state_province', $fields);
+  }
+
+}


### PR DESCRIPTION
This pull request is part of a work intended to make CiviCRM use different sets of billing fields per payment processor.

Please check https://github.com/civicrm/civicrm-core/pull/20811 for more information.