### PR TITLE
Fix for #198: Double Receipts & Payment Details from Cybersource Payments

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -816,9 +816,11 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
     if ($response->isSuccessful()) {
       try {
         //cope with CRM14950 not being implemented
-        $this->loadContribution();
 
-        if ($this->getLock() && $this->contribution['contribution_status_id:name'] !== 'Completed') {
+        $lock = Civi::lockManager()->acquire('data.contribute.contribution.' . $this->transaction_id, 5);
+
+        $this->loadContribution();
+        if ($this->contribution['contribution_status_id:name'] !== 'Completed') {
           $this->gatewayConfirmContribution($response);
           $trxnReference = $response->getTransactionReference();
           civicrm_api3('contribution', 'completetransaction', [


### PR DESCRIPTION
This patch solves the problem explained in #198 related to Cybersource, and it seems (to me) like it should not negatively affect other processors. However, see [my comment in that ticket](https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/198#issuecomment-969430368) expressing uncertainty over why this patch would even be needed.  

In other words, this solves the problem, but I don't know why.