### PR TITLE
FAC Gateway version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "fuzion/omnipay-mercanet": "^3.0@dev",
         "razorpay/omnipay-razorpay": "^3.0@dev",
         "clue/stream-filter": "^1.4.1",
-        "cloudcogsio/omnipay-firstatlanticcommerce-gateway" : "~1.0.0"
+        "cloudcogsio/omnipay-firstatlanticcommerce-gateway" : "^1.0.2"
     },
     "replace": {
       "guzzlehttp/guzzle": "^6.0",


### PR DESCRIPTION
- Gateway (v1.0.2) supports auto-generating OrderNumbers (TransactionIds) if none is passed by the application. 
- Observed behaviour with Event payments in Civi where the gateway is not provided with a TransactionId.