### PR TITLE
Fix amount change on recur contribution

### DIFF
--- a/api/v3/Job/ProcessRecurring.php
+++ b/api/v3/Job/ProcessRecurring.php
@@ -29,15 +29,17 @@ function civicrm_api3_job_process_recurring($params) {
         'contribution_test' => CRM_Utils_Array::value('is_test', $recurringPayment['is_test']),
       ]);
       $result[$recurringPayment['id']]['original_contribution'] = $originalContribution;
+      $totalAmount = $recurringPayment['amount'] ?? $originalContribution['total_amount'];
       $pending = civicrm_api3('Contribution', 'repeattransaction', [
         'original_contribution_id' => $originalContribution['id'],
         'contribution_status_id' => 'Pending',
         'payment_processor_id' => $paymentProcessorID,
         'is_email_receipt' => FALSE,
+        'total_amount' => $totalAmount,
       ]);
 
       $payment = civicrm_api3('PaymentProcessor', 'pay', [
-        'amount' => $originalContribution['total_amount'],
+        'amount' => $totalAmount,
         'currency' => $originalContribution['currency'],
         'payment_processor_id' => $paymentProcessorID,
         'contributionID' => $pending['id'],


### PR DESCRIPTION
Looks like omnipay extension allows to update the amount for the recur contributions - https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/blob/master/CRM/Core/Payment/OmnipayMultiProcessor.php#L1094

But when this is done, it still takes the original amount for the payment and not the "updated" amount. See https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/blob/master/api/v3/Job/ProcessRecurring.php#L40

Fix here ensures the amount from the "recur" table is considered for the next payment and not from the original contribution.  

To replicate the issue:

- Create a recur payment of $2. Allow the first payment to be completed.
- Change the amount on the recur series to $1
- When the next  payment date is arrived, the extension still triggers a payment for $2 instead of $1.