### PR TITLE
Log message if CRM.vars.omnipay are not defined instead of trying to load checkout

### DIFF
--- a/Metadata/js/omnipay_PaypalRest.js
+++ b/Metadata/js/omnipay_PaypalRest.js
@@ -3,6 +3,11 @@
   var form = $('#billing-payment-block').closest('form');
   var qfKey = $('[name=qfKey]', form).val();
 
+  if (typeof CRM.vars.omnipay === 'undefined') {
+    console.log('CRM.vars.omnipay not defined! Not a Omnipay processor?');
+    return;
+  }
+
   function renderPaypal() {
     paypal.Buttons({
 


### PR DESCRIPTION
… when it won't work without the vars