### PR TITLE
Fix description too long error on sagepay

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -569,7 +569,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
     $creditCardOptions = [
       'amount' => $params['amount'],
       'currency' => $this->getCurrency($params),
-      'description' => $params['description'],
+      'description' => substr($params['description'], 0, 64),
       'transactionId' => $this->formatted_transaction_id,
       'clientIp' => CRM_Utils_System::ipAddress(),
       'returnUrl' => $this->getNotifyUrl(TRUE),
@@ -1721,4 +1721,3 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
   }
 
 }
-


### PR DESCRIPTION
```
May 12 11:18:29  [alert] failed processor transaction omnipay_SagePay_Server
Array
(
    [INVALID] => 3082 : The Description value is too long.
)
```

[Sage pay allows 100 chars](https://developer-eu.elavon.com/docs/opayo/spec/api-reference#operation/createTransaction) but limiting it to 64 so that it is not affected with other payment gateways

Regression from  https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/232