### PR TITLE
Fix populateEntities so we actually load metadata

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -1340,7 +1340,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    * Copied from civix as was being internally used.
    */
   private function populateEntities(&$entities) {
-    $mgdFiles = CRM_Utils_File::findFiles(__DIR__, '*.mgd.php');
+    $mgdFiles = CRM_Utils_File::findFiles(E::path(), '*.mgd.php');
     sort($mgdFiles);
     foreach ($mgdFiles as $file) {
       $es = include $file;


### PR DESCRIPTION
Tested on both a drupal 9 and WordPress site. Before this patch findFiles works in CRM/Core/Payment directory. After works in "root" of omnipay extension directory.