### PR TITLE
Integration with Form Processor

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -572,7 +572,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
       'description' => substr($params['description'], 0, 64),
       'transactionId' => $this->formatted_transaction_id,
       'clientIp' => CRM_Utils_System::ipAddress(),
-      'returnUrl' => $this->getNotifyUrl(TRUE),
+      'returnUrl' => $this->getReturnUrl(),
       'cancelUrl' => $this->getCancelUrl($this->getQfKey(), CRM_Utils_Array::value('participantID', $params)),
       'errorUrl' => $this->getReturnFailUrl($this->getQfKey(), $participantID, $eventID),
       'notifyUrl' => $this->getNotifyUrl(),
@@ -1160,8 +1160,14 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
           // This is kinda tricky - in that it's not denoted on that class anywhere
           // & as we integrate more we might need to refine this early return
           // to be metadata based or to have some jsv4 specific paypal class.
-          return ['pre_approval_parameters' => ['token' => $response->getTransactionReference()]];
+          return [
+            'pre_approval_parameters' => ['token' => $response->getTransactionReference()],
+            'redirect_url' => $response->getRedirectURL(),
+          ];
         }
+        return [
+          'redirect_url' => $response->getRedirectURL(),
+        ];
         /*
          * This is what we expect to do but no current processors.
         $isTransparentRedirect = ($response->isTransparentRedirect() || !empty($this->gateway->transparentRedirect));

--- a/CRM/Core/Payment/PaymentExtended.php
+++ b/CRM/Core/Payment/PaymentExtended.php
@@ -81,6 +81,11 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
   protected $history = [];
 
   /**
+   * @var String
+   */
+  protected $returnUrl;
+
+  /**
    * @return \CRM_Utils_SystemLogger
    */
   public function getLog() {
@@ -127,6 +132,31 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
       ),
       TRUE, NULL, FALSE, TRUE
     );
+  }
+
+  /**
+   * Get the URL for return.
+   * Default value is the notify url
+   *
+   * @return string
+   */
+  protected function getReturnUrl() {
+    if (isset($this->returnUrl)) {
+      return $this->returnUrl;
+    }
+    return $this->getNotifyUrl(TRUE);
+  }
+
+  /**
+   * Sets or unsets the return url.
+   * If the return url is not set it is set to notify url
+   *
+   * @param string|NULL $returnUrl
+   *
+   * @return void
+   */
+  public function setReturnUrl(string $returnUrl = null) {
+    $this->returnUrl = $returnUrl;
   }
 
   /**

--- a/Civi/OmnipayMultiProcessor/ActionProvider/CompilerPass.php
+++ b/Civi/OmnipayMultiProcessor/ActionProvider/CompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Civi\OmnipayMultiProcessor\ActionProvider;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use CRM_Omnipaymultiprocessor_ExtensionUtil as E;
+
+class CompilerPass implements CompilerPassInterface {
+
+  public function process(ContainerBuilder $container) {
+    if ($container->hasDefinition('action_provider')) {
+      $actionProviderDefinition = $container->getDefinition('action_provider');
+      $actionProviderDefinition->addMethodCall('addAction',
+        [
+          'OmnipayMultiProcessor_OnlinePayment',
+          'Civi\OmnipayMultiProcessor\ActionProvider\DoOnlinePayment',
+          E::ts('Contribution: Do Online Payment with Omnipay Multi Processor'),
+          []
+        ]);
+    }
+
+  }
+
+}

--- a/Civi/OmnipayMultiProcessor/ActionProvider/DoOnlinePayment.php
+++ b/Civi/OmnipayMultiProcessor/ActionProvider/DoOnlinePayment.php
@@ -1,0 +1,124 @@
+<?php
+
+
+namespace Civi\OmnipayMultiProcessor\ActionProvider;
+
+use Civi\ActionProvider\Action\AbstractAction;
+use Civi\ActionProvider\Exception\ExecutionException;
+use Civi\ActionProvider\Parameter\OptionGroupSpecification;
+use Civi\ActionProvider\Parameter\ParameterBagInterface;
+use Civi\ActionProvider\Parameter\Specification;
+use Civi\ActionProvider\Parameter\SpecificationBag;
+use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\PaymentProcessor;
+use CRM_Core_Exception;
+use CRM_Omnipaymultiprocessor_ExtensionUtil as E;
+
+class DoOnlinePayment extends AbstractAction {
+
+  /**
+   * @var array
+   */
+  protected $paymentProcessors;
+
+  /**
+   * Run the action
+   *
+   * @param ParameterBagInterface $parameters
+   *   The parameters to this action.
+   * @param ParameterBagInterface $output
+   * 	 The parameters this action can send back
+   * @return void
+   * @throws \Exception
+   */
+  protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output) {
+    $paymentParams['contribution_id'] = $parameters->getParameter('contribution_id');
+    $paymentParams['amount'] = (float) $parameters->getParameter('total_amount');
+    $paymentParams['currency'] = $parameters->getParameter('currency');
+    $paymentParams['description'] = $parameters->getParameter('description');
+    $successUrl = $parameters->getParameter('success_url');
+    $cancelurl = $parameters->getParameter('cancel_url');
+
+    $paymentProcessor = $this->getPaymentProcessorByName($this->configuration->getParameter('payment_processor'));
+    if (!$paymentProcessor) {
+      throw new ExecutionException('Invalid Payment Processor');
+    }
+    $payment = \Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
+    if ($payment instanceof \CRM_Core_Payment_PaymentExtended) {
+      $payment->setReturnUrl($successUrl);
+    }
+    $payment->setBaseReturnUrl($successUrl);
+    $payment->setSuccessUrl($successUrl);
+    $payment->setCancelUrl($cancelurl);
+    $result = $payment->doPreApproval($paymentParams);
+    $output->setParameter('redirect_url', $result['redirect_url']);
+  }
+
+  /**
+   * @return \Civi\ActionProvider\Parameter\SpecificationBag
+   */
+  public function getOutputSpecification() {
+    return new SpecificationBag(array(
+      new Specification('redirect_url', 'String', E::ts('Redirect URL'), false),
+    ));
+  }
+
+  /**
+   * Returns the specification of the configuration options for the actual action.
+   *
+   * @return SpecificationBag
+   */
+  public function getConfigurationSpecification() {
+    $paymentProcessorOptions = [];
+    foreach($this->getPaymentProcessors() as $paymentProcessor) {
+      $paymentProcessorOptions[$paymentProcessor['name']] = $paymentProcessor['title'];
+    }
+    return new SpecificationBag(array(
+      new Specification('payment_processor', 'String', E::ts('Payment Processor'), TRUE, null, null, $paymentProcessorOptions),
+    ));
+  }
+
+  /**
+   * Returns the specification of the parameters of the actual action.
+   *
+   * @return SpecificationBag
+   */
+  public function getParameterSpecification() {
+    return new SpecificationBag([
+      new Specification('contribution_id', 'Integer', E::ts('Contribution ID'), TRUE),
+      new Specification('total_amount', 'Float', E::ts('Amount'), TRUE),
+      new OptionGroupSpecification('currency', 'currencies_enabled', E::ts('Currency'), TRUE),
+      new Specification('success_url', 'String', E::ts('Success URL'), TRUE),
+      new Specification('cancel_url', 'String', E::ts('Cancel URL'), TRUE),
+      new Specification('description', 'String', E::ts('Payment Description'), TRUE),
+    ]);
+  }
+
+  public function getHelpText() {
+    return E::ts('This action creates an online payment at a payment processor and returns the url at which the user can finish the payment');
+  }
+
+  private function getPaymentProcessors() {
+    if (empty($this->paymentProcessors)) {
+      try {
+        $this->paymentProcessors = PaymentProcessor::get(FALSE)
+          ->addWhere('is_active', '=', TRUE)
+          ->execute()
+          ->getArrayCopy();
+      }
+      catch (UnauthorizedException|CRM_Core_Exception $e) {
+      }
+    }
+    return $this->paymentProcessors;
+  }
+
+  private function getPaymentProcessorByName(string $name):? array {
+    foreach($this->getPaymentProcessors() as $paymentProcessor) {
+      if ($paymentProcessor['name'] == $name) {
+        return $paymentProcessor;
+      }
+    }
+    return null;
+  }
+
+}

--- a/omnipaymultiprocessor.php
+++ b/omnipaymultiprocessor.php
@@ -2,6 +2,18 @@
 
 require_once 'omnipaymultiprocessor.civix.php';
 use CRM_Omnipaymultiprocessor_ExtensionUtil as E;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use \Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Implements hook_civicrm_container()
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
+ */
+function omnipaymultiprocessor_civicrm_container(ContainerBuilder $container) {
+  $container->addCompilerPass(new Civi\OmnipayMultiProcessor\ActionProvider\CompilerPass(), PassConfig::TYPE_OPTIMIZE);
+}
+
 
 /**
  * Implementation of hook_civicrm_config


### PR DESCRIPTION
This PR integrates the omnipay multiprocessor extension with the Form Processor. 

It adds an action to the form processor `Contribution: Do online payment with Omnipay Multi Processor` which creates a payment at the paymen processor and returns the url to which the payer (user) should be redirected. The redirect it self does not happen as that needs to happen outside of CiviCRM. The Webform Form Processor module for Drupal 10 can handle this situation.

![2023-11-07_22-04](https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/assets/4126292/be254f7d-dd96-47ee-8e3a-5d7d236d8b4f)


**Benefits of this solution**

The benefit of this solution is that we don't need to implement payment functionality at the website or external systems. Instead we use CiviCRM to generate payments. This way we can remove personal data out of the website a bit sooner. Right now we have to keep them in the website till the payment is completed.

**How does this  work technically?**

The atcion does the following:

1. At the payment processor level it calls the `doPreApproval`
2. that function can return the redirect url (if the payment processor expects the user to be redirected)
3. the redirect is then given back to the form processor

**Technicall changes**

To get this working I had to change a few things:

-  in the  `doPreApproval` function add the redirect url as a return parameter.
-  At the abbility to set a  `returnUrl` . By default this is the `notifyUrl` . The form processor action overrides this with a different url (as in my use case the user cannot be redirect to a civicrm page, as civicrm is behind a firewall).