### PR TITLE
Fix a problem with php 8 and civicrm 5.67.1

### DIFF
--- a/vendor/symfony/http-foundation/ResponseHeaderBag.php
+++ b/vendor/symfony/http-foundation/ResponseHeaderBag.php
@@ -90,7 +90,7 @@ class ResponseHeaderBag extends HeaderBag
      *
      * @param string|null $key The name of the headers to return or null to get them all
      */
-    public function all(/*string $key = null*/)
+    public function all(?string $key = null): array
     {
         $headers = parent::all();
 
@@ -166,15 +166,14 @@ class ResponseHeaderBag extends HeaderBag
     /**
      * {@inheritdoc}
      */
-    public function hasCacheControlDirective($key)
-    {
+    public function hasCacheControlDirective($key): bool {
         return \array_key_exists($key, $this->computedCacheControl);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getCacheControlDirective($key)
+    public function getCacheControlDirective($key): string|bool|null
     {
         return $this->computedCacheControl[$key] ?? null;
     }


### PR DESCRIPTION
When I installed this in our demo environment I discovered a compatibility issue with php 8 and civicrm 5.67.1 and Drupal 10.

Not sure whether this breaks other compatibility, such as Drupal 7, or wordpress or older versions of CiviCRM.