### PR TITLE
We should align the replacement version here with the requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
       "guzzlehttp/guzzle": "^6.5 || ^7.0",
       "guzzlehttp/psr7": "^1",
       "psr/http-message-implementation": "^1.0",
-      "psr/log" : "^1",
+      "psr/log": "^1.0 || ^2.0 || ^3.0",
       "psr/http-message": "^1.0.1"
     },
     "require-dev": {


### PR DESCRIPTION
Updates the 'replaces' syntax to align with civicrm core requirements.