### PR TITLE
Add PowerTranz (formerly FAC) 3DS2 processor

### DIFF
--- a/Metadata/omnipay_PowerTranz.mgd.php
+++ b/Metadata/omnipay_PowerTranz.mgd.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Ricardo Assing (ricardo@tsiana.ca)
+ * 
+ * CiviCRM specific file to be used with 
+ * eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor 
+ */
+return [
+  [
+    'name' => 'OmniPay - PowerTranz',
+    'entity' => 'payment_processor_type',
+    'params' => [
+      'version' => 3,
+      'title' => 'OmniPay - PowerTranz 3DS2',
+      'name' => 'omnipay_PowerTranz',
+      'description' => 'PowerTranz (formerly FAC) 3DS2 Payment Processor. This replaces the previous FAC processor.',
+      'user_name_label' => 'PowerTranz ID',
+      'password_label' => 'PowerTranz Password',
+      'class_name' => 'Payment_OmnipayMultiProcessor',
+      'billing_mode' => 1,
+      'payment_type' => 1,
+      'is_recur' => 0,
+    ]
+  ],
+];

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "razorpay/omnipay-razorpay": "^3.0@dev",
         "clue/stream-filter": "^1.4.1",
         "cloudcogsio/omnipay-firstatlanticcommerce-gateway" : "*",
+        "cloudcogsio/omnipay-powertranz-3ds2-gateway" : "*",
         "hounddd/omnipay-systempay": "dev-master",
         "ext-json": "*"
     },


### PR DESCRIPTION
Pending @cloudcogsio accepting https://github.com/cloudcogsio/omnipay-powertranz-3ds2-gateway/pull/1 this should add PowerTranz's (formerly FAC) 3DS2 processor to the extension.