### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -265,8 +265,8 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
     $this->ensurePaymentProcessorTypeIsSet();
     $this->createGatewayObject();
     $this->setProcessorFields();
-    $this->setContributionReference(CRM_Utils_Array::value('contributionID', $params));
-    $this->storeReturnUrls(CRM_Utils_Array::value('participantID', $params), CRM_Utils_Array::value('eventID', $params));
+    $this->setContributionReference($params['contributionID'] ?? NULL);
+    $this->storeReturnUrls($params['participantID'] ?? $params['eventID'] ?? NULL);
   }
 
   /**
@@ -784,7 +784,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
     $params = array_merge($_GET, $_REQUEST);
     if (empty($params['payment_processor_id'])) {
       // CRM-16422 we need to be prepared for the payment processor id to be in the url instead.
-      $q = explode('/', CRM_Utils_Array::value('q', $params, ''));
+      $q = explode('/', $params['q'] ?? '');
       $lastParam = array_pop($q);
       if (is_numeric($lastParam)) {
         $params['processor_id'] = $lastParam;
@@ -1541,7 +1541,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
 
     // and, at least with Way rapid, the createCreditCard call ignores any attempt to authorise.
     // that is likely to be a pattern.
-    $action = CRM_Utils_Array::value('payment_action', $params, 'purchase');
+    $action = $params['payment_action'] ?? 'purchase';
     // This is a bit tricky. With Paypal there are 2 flows
     // 1) you get a token from paypal checkout but there is no recurring - this token needs to be 'completed'
     // 2) you have a recurring payment token that we can bill against. However, is_recur is not

--- a/CRM/Core/Payment/PaymentExtended.php
+++ b/CRM/Core/Payment/PaymentExtended.php
@@ -393,7 +393,7 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
           $processor = civicrm_api3('PaymentProcessor',
             'getsingle', ['id' => $this->_paymentProcessor['id']]
           );
-          return CRM_Utils_Array::value($paymentField['name'], $processor);
+          return $processor[$paymentField['name']] ?? NULL;
         }
     }
   }

--- a/api/v3/Job/ProcessRecurring.php
+++ b/api/v3/Job/ProcessRecurring.php
@@ -25,8 +25,8 @@ function civicrm_api3_job_process_recurring($params) {
       $originalContribution = civicrm_api3('Contribution', 'getsingle', [
         'contribution_recur_id' => $recurringPayment['id'],
         'options' => ['limit' => 1],
-        'is_test' => CRM_Utils_Array::value('is_test', $recurringPayment['is_test']),
-        'contribution_test' => CRM_Utils_Array::value('is_test', $recurringPayment['is_test']),
+        'is_test' => $recurringPayment['is_test']['is_test'] ?? NULL,
+        'contribution_test' => $recurringPayment['is_test']['is_test'] ?? NULL,
       ]);
       $result[$recurringPayment['id']]['original_contribution'] = $originalContribution;
       $totalAmount = $recurringPayment['amount'] ?? $originalContribution['total_amount'];


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.