### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Core/Page/PaymentPage.php
+++ b/CRM/Core/Page/PaymentPage.php
@@ -14,7 +14,7 @@ class CRM_Core_Page_PaymentPage extends CRM_Core_Page {
    * Page run function.
    *
    * @return string
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     $formData = $this->getTransparentRedirectFormData(CRM_Utils_Request::retrieve('key', 'String', CRM_Core_DAO::$_nullObject, TRUE));

--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -1721,7 +1721,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
    * @param array $params
    *
    * @return mixed
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function getContactID(array $params) {

--- a/CRM/Core/Payment/PaymentExtended.php
+++ b/CRM/Core/Payment/PaymentExtended.php
@@ -249,7 +249,7 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
    *
    * @return string
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function getPaymentTypeLabel() {
     if (!isset($this->payment_type_label)) {
@@ -324,7 +324,7 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
    * Get array of fields that should be displayed on the payment form.
    *
    * @return array
-   * @throws CiviCRM_API3_Exception
+   * @throws CRM_Core_Exception
    */
   public function getPaymentFormFields() {
     $paymentType = civicrm_api3('option_value', 'getvalue', array('value' => $this->_paymentProcessor['payment_type'], 'option_group_id' => 'payment_type', 'return' => 'name'));
@@ -383,7 +383,7 @@ abstract class CRM_Core_Payment_PaymentExtended extends CRM_Core_Payment {
    *
    * @return string
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function getPrefix() {
     $paymentFields = civicrm_api3('PaymentProcessor', 'getfields', []);

--- a/api/v3/Job/ProcessRecurring.php
+++ b/api/v3/Job/ProcessRecurring.php
@@ -7,7 +7,7 @@
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_process_recurring($params) {
   $omnipayProcessors = civicrm_api3('PaymentProcessor', 'get', ['class_name' => 'Payment_OmnipayMultiProcessor', 'domain_id' => CRM_Core_Config::domainID()]);
@@ -62,7 +62,7 @@ function civicrm_api3_job_process_recurring($params) {
       $result['success']['ids'] = $recurringPayment['id'];
 
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       // Failed - what to do?
       civicrm_api3('ContributionRecur', 'create', [
         'id' => $recurringPayment['id'],

--- a/api/v3/PaymentProcessor/Getmissing.php
+++ b/api/v3/PaymentProcessor/Getmissing.php
@@ -5,8 +5,8 @@
  *
  * @param array $params
  *
- * @throws API_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
+ * @throws CRM_Core_Exception
  *
  * @return array
  *   API Result array

--- a/api/v3/PaymentProcessor/Postapprove.php
+++ b/api/v3/PaymentProcessor/Postapprove.php
@@ -6,14 +6,14 @@
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_payment_processor_postapprove($params) {
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
   $result = $processor->doPostApproval($params);
   if (is_a($result, 'CRM_Core_Error')) {
-    throw API_Exception('Payment failed');
+    throw CRM_Core_Exception('Payment failed');
   }
   return civicrm_api3_create_success(array($result['pre_approval_parameters']), $params);
 }

--- a/api/v3/PaymentProcessor/Preapprove.php
+++ b/api/v3/PaymentProcessor/Preapprove.php
@@ -6,14 +6,14 @@
  *
  * @return array
  *   API result array.
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_payment_processor_preapprove($params) {
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', array('id' => $params['payment_processor_id'])));
   $result = $processor->doPreApproval($params);
   if (is_a($result, 'CRM_Core_Error')) {
-    throw API_Exception('Payment failed');
+    throw CRM_Core_Exception('Payment failed');
   }
   return civicrm_api3_create_success(array($result['pre_approval_parameters']), $params);
 }

--- a/api/v3/PaymentProcessor/Query.php
+++ b/api/v3/PaymentProcessor/Query.php
@@ -5,8 +5,8 @@
  *
  * @param array $params
  *
- * @throws API_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
+ * @throws CRM_Core_Exception
  *
  * @return array
  *   API Result array

--- a/api/v3/PaymentProcessor/RecurQuery.php
+++ b/api/v3/PaymentProcessor/RecurQuery.php
@@ -5,8 +5,8 @@
  *
  * @param array $params
  *
- * @throws API_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
+ * @throws CRM_Core_Exception
  *
  * @return array
  *   API Result array

--- a/api/v3/PaymentProcessor/Retrymissing.php
+++ b/api/v3/PaymentProcessor/Retrymissing.php
@@ -11,8 +11,8 @@
  *
  * @param array $params
  *
- * @throws API_Exception
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
+ * @throws CRM_Core_Exception
  *
  * @return array
  *   API Result array

--- a/tests/phpunit/BillingFieldsTest.php
+++ b/tests/phpunit/BillingFieldsTest.php
@@ -37,7 +37,7 @@ class BillingFieldsTest extends TestCase implements HeadlessInterface, HookInter
   /**
    * Setup for test.
    *
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \CRM_Csore_Exception
    */
   public function setUp():void {

--- a/tests/phpunit/EwayTest.php
+++ b/tests/phpunit/EwayTest.php
@@ -45,7 +45,7 @@ class EwayTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface,
   }
 
   /**
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function testTransparentDirectDisplayFields() {
     $processor = $this->createTestProcessor('Eway_Rapid');

--- a/tests/phpunit/IPNTest.php
+++ b/tests/phpunit/IPNTest.php
@@ -39,7 +39,7 @@ class IPNTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, 
   /**
    * Example: Test that a version is returned.
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    * @throws \CRM_Core_Exception
    */
   public function testIPN() {

--- a/tests/phpunit/SagepayTest.php
+++ b/tests/phpunit/SagepayTest.php
@@ -42,7 +42,7 @@ class SagepayTest extends TestCase implements HeadlessInterface, HookInterface, 
   /**
    * Setup for test.
    *
-   * @throws \API_Exception
+   * @throws \CRM_Core_Exception
    * @throws \CRM_Core_Exception
    */
   public function setUp():void {
@@ -79,7 +79,7 @@ class SagepayTest extends TestCase implements HeadlessInterface, HookInterface, 
    * must be saved as part of the `trxn_id` JSON.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function testDoSinglePayment(): void {
     Civi::$statics['Omnipay_Test_Config'] = [ 'client' => $this->getHttpClient() ];
@@ -130,7 +130,7 @@ class SagepayTest extends TestCase implements HeadlessInterface, HookInterface, 
    * must be saved as part of the `trxn_id` JSON.
    *
    * @throws \CRM_Core_Exception
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function testDoRecurPayment(): void {
     $this->setMockHttpResponse([


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.