### PR TITLE
Fix balance corruption when IPN completes a partially paid contribution

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -259,6 +259,7 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
           CRM_Utils_System::redirect($url);
         }
         $response->redirect();
+        CRM_Utils_System::civiExit();
       }
       else {
         return $this->handleError('alert', 'failed processor transaction ' . $this->_paymentProcessor['payment_processor_type'], [$response->getCode() => $response->getMessage()]);
@@ -870,11 +871,44 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
         if ($this->getLock() && $this->contribution['contribution_status_id:name'] !== 'Completed') {
           $this->gatewayConfirmContribution($response);
           $trxnReference = $response->getTransactionReference();
-          civicrm_api3('contribution', 'completetransaction', [
-            'id' => $this->transaction_id,
-            'trxn_id' => $trxnReference,
-            'payment_processor_id' => $params['processor_id'],
-          ]);
+          $contributionStatus = $this->contribution['contribution_status_id:name'] ?? '';
+          if (in_array($contributionStatus, ['Partially paid', 'Pending'], TRUE)) {
+            // The contribution already carries an outstanding balance (e.g. it received an
+            // earlier partial payment, or is a pay-later contribution being settled now).
+            // completetransaction() would record the FULL original contribution amount as
+            // paid rather than the amount the processor actually reports for this
+            // transaction, corrupting the balance (see dev/financial#174). Route through
+            // Payment::create instead, which records only the actual amount and lets core
+            // recompute the balance/status.
+            $balanceAmount = (float) (civicrm_api4('Contribution', 'get', [
+              'select' => ['balance_amount'],
+              'where' => [['id', '=', $this->transaction_id]],
+            ])->first()['balance_amount'] ?? 0);
+            $paymentAmount = (float) $response->getAmount();
+            // Guard against processors that don't report an amount here, and never
+            // register more than the outstanding balance.
+            if ($paymentAmount <= 0 || $paymentAmount > $balanceAmount) {
+              $paymentAmount = $balanceAmount;
+            }
+            if ($paymentAmount > 0) {
+              civicrm_api4('Payment', 'create', [
+                'values' => [
+                  'contribution_id' => (int) $this->transaction_id,
+                  'total_amount' => $paymentAmount,
+                  'trxn_id' => $trxnReference,
+                  'payment_processor_id' => (int) ($params['processor_id'] ?? 0),
+                  'trxn_date' => date('Y-m-d H:i:s'),
+                ],
+              ]);
+            }
+          }
+          else {
+            civicrm_api3('contribution', 'completetransaction', [
+              'id' => $this->transaction_id,
+              'trxn_id' => $trxnReference,
+              'payment_processor_id' => $params['processor_id'],
+            ]);
+          }
           if (!empty($this->contribution['contribution_recur_id']) && $trxnReference) {
             $this->updatePaymentTokenWithAnyExtraData($trxnReference);
           }


### PR DESCRIPTION
## Problem

When the IPN handler's `handlePaymentNotification()` receives a successful response for a contribution that isn't yet `Completed`, it unconditionally calls `completetransaction`, which assumes this IPN represents the *first and only* payment against the contribution. That's correct for the common case (fresh registration, paid in full, first attempt). It's wrong whenever the contribution already carries an outstanding balance smaller than its total — e.g.:

- an earlier partial payment was already recorded (status `Partially paid`), and this IPN is for the *remaining* balance;
- the contribution was created pay-later (status `Pending`) and this IPN settles it later.

In both cases `completetransaction` records the transaction as being for the full original contribution amount, not the amount the processor actually reports for *this* transaction. The contribution ends up `Completed`, but the payment ledger shows more money received than was actually charged — the balance is corrupted.

This is a confirmed, still-open core issue: **[dev/financial#174](https://lab.civicrm.org/dev/financial/-/issues/174)** — "Partial payment records amount of full contribution disrupting balance", reported 2021, reproduced with exactly this scenario (contribution €155, initial payment €55, remaining €100 paid via the user-dashboard Pay Now button → contribution correctly shows `Completed`, but the payment transaction is recorded as the full €155 instead of the €100 actually paid). Checked current `master`: the blind `completetransaction` call is still present, unchanged, 5+ years later.

This affects any site where a contribution can receive more than one payment through this extension — event registrations with instalments, membership balance top-ups, pledges, or any pay-later flow settled online later.

## Fix

Before completing the transaction, check the contribution's current status. If it is `Partially paid` or `Pending` with an outstanding balance, route through `Payment::create` with the amount the processor actually reports (`$response->getAmount()`), capped defensively at the outstanding balance. `Payment::create` records only that amount, adjusts the balance correctly, and lets core flip the contribution to `Completed` once the balance reaches zero.

For the ordinary case (no prior payment), behaviour is unchanged — `completetransaction` still runs exactly as before. Risk of regression for the vast majority of installs (single, full, first-time payments) should be minimal.

Also bundles a small, unrelated defensive fix: `CRM_Utils_System::civiExit()` after `$response->redirect()` in `doPayment()`, so execution doesn't continue past a redirect that has already sent output. Scoped only to the `doPayment()` redirect path; the separate `doPreApproval()` redirect flow is untouched.

## Test plan

Verified against a live CiviCRM 6.15 instance via `Payment::create` directly (the same call this PR routes the IPN handler to):
- Pending contribution, single payment for less than the total → `Partially paid`, balance reduced by exactly the paid amount (not the full total).
- Pending contribution, two payments summing to the total → `Completed`, balance 0, no over-recording at any point.

These match the reproduction case described in dev/financial#174.

## Related reports

- **dev/financial#174** (open) — the exact bug this fixes; I reported this in 2021 against the core dashboard Pay Now flow, still unresolved. This PR fixes the same failure mode in this extension's IPN handler specifically.
- **#58** "No email when partially paid contribution is fulfilled" (open, 2018) — related but different: a missing confirmation email on completion, not the amount-recording bug this PR addresses.
- **#182** (merged) — touches the same `doPayment()`/redirect area but a different concern (trxn-reference persistence for transparent-redirect processors); no overlap.
