### PR TITLE
Add supportsRefund/doRefund for gateways whose Omnipay driver implements refund

### DIFF
--- a/CRM/Core/Payment/OmnipayMultiProcessor.php
+++ b/CRM/Core/Payment/OmnipayMultiProcessor.php
@@ -272,6 +272,100 @@ class CRM_Core_Payment_OmnipayMultiProcessor extends CRM_Core_Payment_PaymentExt
   }
 
   /**
+   * Does this processor support refunds?
+   *
+   * Generic for any Omnipay gateway that exposes a refund() method
+   * (the tested target is Mollie). The gateway class is resolved without
+   * instantiating it, so this is safe to call in listing contexts.
+   *
+   * @return bool
+   */
+  public function supportsRefund() {
+    try {
+      $this->ensurePaymentProcessorTypeIsSet();
+      $shortName = str_replace('omnipay_', '', $this->_paymentProcessor['payment_processor_type']);
+      $gatewayClass = \Omnipay\Common\Helper::getGatewayClassName($shortName);
+      return class_exists($gatewayClass) && method_exists($gatewayClass, 'refund');
+    }
+    catch (\Exception $e) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Submit a refund to the payment processor.
+   *
+   * Generic for any Omnipay gateway that exposes a refund() method; the
+   * tested target is Mollie. On failure an exception is thrown (rather than
+   * returning a failure array) so that CiviCRM never records a refund that
+   * the gateway rejected.
+   *
+   * @param array $params
+   *   Expected keys: trxn_id (the gateway's original transaction reference),
+   *   amount, and optionally currency (resolved from the original financial
+   *   transaction when omitted).
+   *
+   * @return array
+   *   refund_trxn_id, refund_status ('Completed'), fee_amount, trxn_date.
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   */
+  public function doRefund(&$params) {
+    if (empty($params['trxn_id']) || empty($params['amount'])) {
+      throw new \Civi\Payment\Exception\PaymentProcessorException('doRefund requires trxn_id and amount');
+    }
+    $currency = $params['currency'] ?? NULL;
+    if (empty($currency)) {
+      // Look up the currency of the original transaction so the refund is
+      // issued in the same currency; fall back to the default currency.
+      $originalTrxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+        ->addSelect('currency')
+        ->addWhere('trxn_id', '=', $params['trxn_id'])
+        ->execute()
+        ->first();
+      $currency = $originalTrxn['currency'] ?? $this->getCurrency($params);
+    }
+    $this->ensurePaymentProcessorTypeIsSet();
+    $this->createGatewayObject();
+    $this->setProcessorFields();
+
+    $refundOptions = [
+      'action' => 'Refund',
+      'transactionReference' => $params['trxn_id'],
+      'amount' => \Civi::format()->machineMoney($params['amount'], $currency),
+      'currency' => $currency,
+      // Mollie requires a description; it may be shown to the customer
+      // (e.g. on their bank statement) depending on the payment method.
+      'description' => $params['description'] ?? ts('Refund of payment %1', [1 => $params['trxn_id']]),
+    ];
+    CRM_Utils_Hook::alterPaymentProcessorParams($this, $params, $refundOptions);
+    unset($refundOptions['action']);
+
+    try {
+      $response = $this->gateway->refund($refundOptions)->send();
+    }
+    catch (\Exception $e) {
+      throw new \Civi\Payment\Exception\PaymentProcessorException('Refund failed: ' . $e->getMessage());
+    }
+    if (!$response->isSuccessful()) {
+      throw new \Civi\Payment\Exception\PaymentProcessorException('Refund failed: ' . $response->getMessage());
+    }
+    return [
+      // Prefer the refund's own reference. Per the Omnipay contract only
+      // getTransactionReference() is guaranteed; getTransactionId() defaults
+      // to null and echoes a merchant-supplied id, which we never send on a
+      // refund - so for standard gateways this falls through to the contract
+      // method. Mollie is the exception: it overrides getTransactionId() to
+      // expose the new refund id (re_...) and keeps the original payment id
+      // (tr_...) in getTransactionReference().
+      'refund_trxn_id' => $response->getTransactionId() ?: $response->getTransactionReference(),
+      'refund_status' => 'Completed',
+      'fee_amount' => 0,
+      'trxn_date' => date('YmdHis'),
+    ];
+  }
+
+  /**
    * Initialize class variables.
    *
    * @param array $params


### PR DESCRIPTION
## Overview

This adds refund support to the processor, wired to CiviCRM's standard refund contract (`supportsRefund()` capability + `doRefund()` as called by the `PaymentProcessor.refund` APIv4 action, and used by e.g. mjwshared's refund UI).

Without this, extensions like mjwshared fall back to their *record-only* branch for any Omnipay processor: the refund is booked in CiviCRM but no money moves at the gateway.

## Approach

- **`supportsRefund()`** resolves the Omnipay gateway class via `\Omnipay\Common\Helper::getGatewayClassName()` **without instantiating it** and returns TRUE only when that class exposes a `refund()` method — so this stays generic across the Omnipay universe and is safe to call in listing contexts.
- **`doRefund()`** initializes the gateway (same sequence `initialize()` uses, minus the form/session steps that need `component`/`qfKey`), then sends `refund(['transactionReference' => trxn_id, 'amount', 'currency'])`. Currency defaults to the original financial_trxn's currency.
- On success it returns `refund_trxn_id` (the gateway's refund id) and `refund_status` 'Completed' per the core contract. **Any failure throws `PaymentProcessorException`** rather than returning a failure array, so CiviCRM never records a refund the gateway rejected.

## Testing

Deployed and verified against Mollie (iDeal/Bancontact) on CiviCRM 6.x: `supportsRefund()` correctly reports TRUE for Mollie processors (whose Omnipay driver implements `refund()`) and would report FALSE for drivers without one. New code passes civilint with zero findings.

Related issue:
https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/issues/242